### PR TITLE
Create a dark mode version and update styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # Custom Axe-Con schedule
 
 This page / site was created to share the [Axe-Con](https://axe-con.com) schedule and add functionality to make it work for **us**.
+
+If you want to test out the site locally, [ThreeJS has a nice set of docs on how to run a local server](https://threejs.org/docs/#manual/en/introduction/How-to-run-things-locally).

--- a/css/custom.css
+++ b/css/custom.css
@@ -1,51 +1,90 @@
 /* Custom styles */
 
 body {
-	font-size: 2em;
-	background-color: #000;
-	color: #fff;
+	font-size: 1.5rem;
+	background-color: #f0f0f0;
+	color: #222;
+}
+
+@media (prefers-color-scheme: dark) {
+	body {
+		background-color: #000;
+		color: #eee;
+	}
 }
 
 h1 {
-	font-size: 1.5em;
-	margin-top: 150px;
-	margin-bottom: 55px;
+	font-size: 3rem;
+	margin-top: 5rem;
+	margin-bottom: 3rem;
 	text-align: center;
 }
 
 a {
-  color: yellow;
-  border-bottom: solid 1px yellow;
+	color: blue;
+	border-bottom: solid 1px blue;
 }
 
 a:hover,
 a:focus {
-	color: orange;
+	color: green;
 	border: none;
 	text-decoration: none;
-	outline: 2px solid #F66;
+	outline: 2px solid rgb(26, 179, 12);
 	outline-offset: 5px;
 }
 
-.axeConDays ul ul li {
-	margin: 25px 15px;
+@media (prefers-color-scheme: dark) {
+	a {
+		color: yellow;
+		border-bottom: solid 1px yellow;
+	}
+	
+	a:hover,
+	a:focus {
+		color: orange;
+		outline: 2px solid #F66;
+	}
 }
 
-.axeConDays ul {
-	margin: 25px 55px;
+.axeConDay {
+	margin: 2rem 2rem;
+}
+
+.axeConHour {
+	margin: 4rem 0;
+}
+
+.axeConHourList {
+	margin: 2rem;
+}
+
+.axeConPresentation {
+	margin: 1rem 0;
 }
 
 #wednesday-date {
-	margin-top: 300px;
-	border-top: solid 3px #fff;
+	margin-top: 8rem;
+	border-top: solid 3px #000;
 	padding-top: 35px;
 }
 
+@media (prefers-color-scheme: dark) {
+	#wednesday-date {
+		border-top: solid 3px #fff;
+	}
+}
+
 .axeConDays h2 {
-	margin-top: 125px;
+	margin-top: 6rem;
 	text-align: center;
+	font-size: 2.5rem;
+}
+
+.axeConDays h3 {
+	font-size: 2rem;
 }
 
 .axeConCollab {
-	margin-bottom: 25px;
+	margin-bottom: 1rem;
 }

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
 		<ul class="list-unstyled axeConDays">
 			<li>
 				<h2 id="thursday-date">Thursday, March 11, 2021</h2>
-				<ul class="list-unstyled" id="thursday" aria-labelledby="thursday-date"></ul>
+				<ul class="list-unstyled axeConDay" id="thursday" aria-labelledby="thursday-date"></ul>
 			</li>
 			<li>
 				<h2 id="wednesday-date">In the past: Wednesday, March 10, 2021</h2>

--- a/js/custom.js
+++ b/js/custom.js
@@ -21,11 +21,8 @@ function toLocaleTime(timeStr, day) {
     0
   ));
 
-  const localeTime = date.toLocaleTimeString();
-  const secondsIndex = localeTime.lastIndexOf(':');
-
-  // remove the seconds
-  return localeTime.substring(0, secondsIndex) + localeTime.substr(secondsIndex + 3);}
+  return date.toLocaleTimeString([], { timeStyle: 'short' });
+}
 
 /**
  * Create the output for a presentation.

--- a/js/custom.js
+++ b/js/custom.js
@@ -33,6 +33,7 @@ function createPresentationOutput(presentation) {
   const { title, presenter, link } = presentation;
 
   const li = document.createElement('li');
+  li.classList.add('axeConPresentation');
   // turn a non-array into an arry
   const presenters = [].concat(presenter);
   li.innerHTML = `<a href="${link}">${title}</a> by ${presenters.join(', ')}`;
@@ -52,12 +53,14 @@ function appendToDom(presentationData, node) {
      const li = document.createElement('li');
      const h3 = document.createElement('h3');
      h3.textContent = time;
+     li.classList.add('axeConHour');
      li.appendChild(h3);
 
      const ul = document.createElement('ul');
      ul.setAttribute('aria-label', `${time}, ${date}`);
-     presentationData[time].forEach(li => {
-       ul.appendChild(li);
+     ul.classList.add('axeConHourList');
+     presentationData[time].forEach(presentationLi => {
+       ul.appendChild(presentationLi);
      });
      li.appendChild(ul);
 


### PR DESCRIPTION
Changes made:
- Simplified time display to "short" format (no seconds)
- Added some documentation on ways to start a local server
- Add classes to different elements
- Reduced body text size
- Increased heading text sizes
- Created dark mode version
- Defaulted to a lighter mode version
- Softened the colors to be (slightly) lower contrast
- Adjusted spacing
- Used rem sizing for spacing and font sizes

@shawnthompson 

## Screenshots
Before:
![Black background with white text and links in yellow. Large size font for all text. Times show hour, minute, and seconds.](https://user-images.githubusercontent.com/6530351/110835476-b2e23e00-8253-11eb-973f-1566a6ee7436.png)

After, default/light:
![Light gray background with dark gray text and links in blue. Body text is smaller but headings are larger. Times show hour and minute.](https://user-images.githubusercontent.com/6530351/110835412-9ba35080-8253-11eb-8da0-97979c60b036.png)

After, dark:
![Similar to default/light, but background with light gray text and links in yellow.](https://user-images.githubusercontent.com/6530351/110835797-1ff5d380-8254-11eb-9755-1218924494af.png)
